### PR TITLE
add support for ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ubidots-mqtt-esp
 
-MQTT library for connecting to Ubidots using MQTT protocol and an ESP8266 chip.
+MQTT library for connecting to Ubidots using MQTT protocol with the ESP8266/ESP32.
 
-## Setup
+## Setup ESP8266
 
 1. Go to the Arduino IDE, click on Files -> Preferences and enter http://arduino.esp8266.com/stable/package_esp8266com_index.json into Additional Board Manager URLs field. You can add multiple URLs, separating them with commas
 2. Open Boards Manager from Tools -> Board menu and install esp8266 platform (and don’t forget to select your ESP8266 board from Tools > Board menu after installation)
@@ -12,6 +12,16 @@ MQTT library for connecting to Ubidots using MQTT protocol and an ESP8266 chip.
 6. Go to Sketch/Program -> Include Library -> Library Manager and install the PubSubClient library 
 7. Close the Arduino IDE and open it again.
 8. If you are using windows, please install the appropiate driver for your ESP board (CH340G if you are using a LoLin board or CP2102 if you are using an AMICA board)
+
+## Setup ESP32
+1. Go to the Arduino IDE, click on Files -> Preferences and enter https://dl.espressif.com/dl/package_esp32_index.json into Additional Board Manager URLs field. You can add multiple URLs, separating them with commas
+2. Open Boards Manager from Tools -> Board menu and install esp32 platform (and don’t forget to select your ESP32 board from Tools > Board menu after installation)
+3. Download this library as .zip
+4. Now, click on Sketch -> Include Library -> Add .ZIP Library
+5. Select the .ZIP file that you have just downloaded and then “Accept” or “Choose”
+6. Go to Sketch/Program -> Include Library -> Library Manager and install the PubSubClient library 
+7. Close the Arduino IDE and open it again.
+8. If you are using windows, please install the appropiate driver for your ESP board (CH340G if you are using a LoLin board)
 
 # Documentation
 

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
-name=Ubidots MQTT for ESP8266
-version=1.1
+name=Ubidots MQTT for ESP8266/ESP32
+version=1.2
 author=Jose García <jose.reyes@ubidots.com>, Mateo Velez
 maintainer=Jose García <jose.reyes@ubidots.com>
-sentence=Library for sending data to the Ubidots cloud using ESP8266 based systems
-paragraph=Library for sending data to the Ubidots cloud using ESP8266 based systems
+sentence=Library for sending data to the Ubidots cloud using ESP8266/ESP32 based systems
+paragraph=Library for sending data to the Ubidots cloud using ESP8266/ESP32 based systems
 category=Other
 url=https://github.com/ubidots/ubidots-mqtt-esp
 architectures=*

--- a/src/UbidotsESPMQTT.cpp
+++ b/src/UbidotsESPMQTT.cpp
@@ -78,7 +78,7 @@ char* Ubidots::getMac(){
     // Obtains the MAC of the device
     Serial.println("entra");
     byte mac[6];
-    WiFi.macAddress(mac);
+    WiFi.macAddress(mac); 
     char macAddr[18];
     sprintf(macAddr, "%2X%2X%2X%2X%2X%2X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
     return macAddr;
@@ -191,7 +191,18 @@ bool Ubidots::wifiConnection(char* ssid, char* pass) {
     Serial.println(F("IP address: "));
     Serial.println(WiFi.localIP());
     if(_clientName==NULL){
+        #ifdef ESP8266 
         _clientName = getMac();
+        #endif    
+
+        #ifdef ESP32
+        char macAddr[24];
+        uint64_t chipid = 0LL;
+        chipid = ESP.getEfuseMac(); //The chip ID is essentially its MAC address for esp32
+        uint16_t chip = (uint16_t)(chipid >> 32);
+        snprintf(macAddr, 24, "%04X%08X",chip, (uint32_t)chipid);
+        _clientName = macAddr;
+        #endif
     }
 }
 

--- a/src/UbidotsESPMQTT.h
+++ b/src/UbidotsESPMQTT.h
@@ -28,14 +28,21 @@ Modified by: Jose Garcia
 #ifndef UbidotsESPMQTT_H
 #define UbidotsESPMQTT_H
 #include "PubSubClient.h"
+
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#define DEFAULT_DEVICE_LABEL "ESP8266"
+#endif
+
+#ifdef ESP32
+#include <WiFi.h>
+#define DEFAULT_DEVICE_LABEL "ESP32"
+#endif
 
 #define MQTT_PORT 1883
 #define SERVER "things.ubidots.com"
 #define MAX_VALUES 5
 #define FIRST_PART_TOPIC "/v1.6/devices/"
-#define DEFAULT_DEVICE_LABEL "ESP8266"
-
 
 #define META_DEBUG Serial
 


### PR DESCRIPTION
Adds the correct Wi-Fi library needed for ESP32, additionally generates `_clientName` using the internal `ESP.getEfuseMac()`.