### PR TITLE
Replace ESP8266WiFi.h with WiFi.h for improved compatibility

### DIFF
--- a/src/UbidotsESPMQTT.h
+++ b/src/UbidotsESPMQTT.h
@@ -27,7 +27,7 @@ Modified by: Jose Garcia
 
 #ifndef UbidotsESPMQTT_H
 #define UbidotsESPMQTT_H
-#include <ESP8266WiFi.h>
+#include <WiFi.h>
 
 #include "PubSubClient.h"
 #include "string.h"


### PR DESCRIPTION
This commit updates the code by replacing **ESP8266WiFi.h** with **WiFi.h**. This change addresses the "_ESP8266WiFi.h: No such file or directory_" error that occurs in the Arduino IDE, ensuring that the code compiles and runs seamlessly across supported platforms. The update improves overall compatibility and maintainability, aligning the project with current library standards.